### PR TITLE
[Resolves #8] Serve raw text files

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -18,6 +18,7 @@ In contrast to ``SimpleHTTPServer`` this development web server:
 - Will return back to normal operation if the folder is recreated.
   Very useful with build systems that perform clean actions.
 - Bind IP can be specified in case security is a must while developing.
+- Open plain text files in the browser (txt, json, yaml, template, config)
 
 As with ``SimpleHTTPServer`` this web server can:
 
@@ -62,6 +63,13 @@ Usage
 
 Changelog
 =========
+
+1.2.0
+-----
+
+**New**
+
+- Open plain text files in the browser (txt, json, yaml, template, config).
 
 1.1.0
 -----

--- a/webdev
+++ b/webdev
@@ -39,7 +39,7 @@ if version_info[0] < 3:
 else:
     from http.server import HTTPServer, SimpleHTTPRequestHandler
 
-__version__ = '1.1.0'
+__version__ = '1.2.0'
 
 log = logging.getLogger(__name__)
 
@@ -51,7 +51,6 @@ V_LEVELS = {
     2: logging.INFO,
     3: logging.DEBUG,
 }
-
 
 class HTTPRequestHandler(SimpleHTTPRequestHandler):
 
@@ -76,6 +75,14 @@ class HTTPRequestHandler(SimpleHTTPRequestHandler):
 
         return SimpleHTTPRequestHandler.send_head(self)
 
+    def end_headers(self):
+        mimetype = self.guess_type(self.path)
+        is_file = not self.path.endswith('/')
+        # This part adds extra headers for some file types.
+        if is_file and mimetype in ['text/plain', 'application/octet-stream']:
+            self.send_header('Content-Type', 'text/plain')
+            self.send_header('Content-Disposition', 'inline')
+        return SimpleHTTPRequestHandler.end_headers(self)
 
 def parse_args(argv=None):
     """


### PR DESCRIPTION
It is convienent to load raw files rather than download them.  This change
will make it so that files are viewable in the browswer when users click
on them.